### PR TITLE
create backends package to handle signing aws requests

### DIFF
--- a/backends/aws.go
+++ b/backends/aws.go
@@ -1,0 +1,33 @@
+package backends
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/smartystreets/go-aws-auth"
+)
+
+func registerNewAwsBackend(u *url.URL, opts *Options, serveMux *http.ServeMux) {
+	path := u.Path
+	u.Path = ""
+	log.Printf("mapping path %q => upstream %q", path, u)
+
+	proxy := httputil.NewSingleHostReverseProxy(u)
+	serveMux.Handle(path, &awsProxy{u, proxy})
+}
+
+type awsProxy struct {
+	upstream *url.URL
+	handler  http.Handler
+}
+
+func (a *awsProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.URL.Host = a.upstream.Host
+	r.URL.Scheme = a.upstream.Scheme
+	r.Host = a.upstream.Host
+	awsauth.Sign4(r)
+	a.handler.ServeHTTP(w, r)
+}

--- a/backends/aws.go
+++ b/backends/aws.go
@@ -3,7 +3,6 @@ package backends
 import (
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 
 	"github.com/smartystreets/go-aws-auth"
@@ -12,9 +11,9 @@ import (
 func registerNewAwsBackend(u *url.URL, opts *Options, serveMux *http.ServeMux) {
 	path := u.Path
 	u.Path = ""
-	log.Printf("mapping path %q => upstream %q", path, u)
+	log.Printf("mapping path %q => aws-upstream %q", path, u)
 
-	proxy := httputil.NewSingleHostReverseProxy(u)
+	proxy := NewReverseProxy(u)
 	serveMux.Handle(path, &awsProxy{u, proxy, opts})
 }
 

--- a/backends/aws.go
+++ b/backends/aws.go
@@ -30,8 +30,8 @@ func (a *awsProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Host = a.upstream.Host
 
 	awsauth.Sign(r, awsauth.Credentials{
-		AccessKeyID:     a.options.ClientKey,
-		SecretAccessKey: a.options.ClientSecret,
+		AccessKeyID:     a.options.AwsAccessKeyId,
+		SecretAccessKey: a.options.AwsSecretAccessKey,
 	})
 	a.handler.ServeHTTP(w, r)
 }

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -51,10 +51,10 @@ type GAPSignatureData struct {
 }
 
 type Options struct {
-	SignatureData  *GAPSignatureData
-	PassHostHeader bool
-	ClientKey      string
-	ClientSecret   string
+	SignatureData      *GAPSignatureData
+	PassHostHeader     bool
+	AwsAccessKeyId     string
+	AwsSecretAccessKey string
 }
 
 // this is what is used to handle urls in the "upstreams" option flag

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -1,0 +1,125 @@
+package backends
+
+import (
+	"crypto"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/18F/hmacauth"
+)
+
+const (
+	BackendTypeAws     = "aws"
+	BackendTypeDefault = "default"
+)
+
+func Register(backendType string, u *url.URL, opts *Options, serveMux *http.ServeMux) {
+	switch backendType {
+	case BackendTypeDefault:
+		registerNewDefaultBackend(u, opts, serveMux)
+	case BackendTypeAws:
+		registerNewAwsBackend(u, opts, serveMux)
+	default:
+		panic(fmt.Errorf("Invalid backendType: %s", backendType))
+	}
+}
+
+// Default Backend Methods
+
+// GAP-Auth Signatures
+const GAPSignatureHeader = "GAP-Signature"
+
+var GAPSignatureHeaders []string = []string{
+	"Content-Length",
+	"Content-Md5",
+	"Content-Type",
+	"Date",
+	"Authorization",
+	"X-Forwarded-User",
+	"X-Forwarded-Email",
+	"X-Forwarded-Access-Token",
+	"Cookie",
+	"Gap-Auth",
+}
+
+type GAPSignatureData struct {
+	Hash crypto.Hash
+	Key  string
+}
+
+type Options struct {
+	SignatureData  *GAPSignatureData
+	PassHostHeader bool
+}
+
+// this is what is used to handle urls in the "upstreams" option flag
+func registerNewDefaultBackend(u *url.URL, opts *Options, serveMux *http.ServeMux) {
+	// handle gap auth
+	var auth hmacauth.HmacAuth
+	if sigData := opts.SignatureData; sigData != nil {
+		auth = hmacauth.NewHmacAuth(sigData.Hash, []byte(sigData.Key),
+			GAPSignatureHeader, GAPSignatureHeaders)
+	}
+	path := u.Path
+	switch u.Scheme {
+	case "http", "https":
+		u.Path = ""
+		log.Printf("mapping path %q => upstream %q", path, u)
+		proxy := httputil.NewSingleHostReverseProxy(u)
+		if !opts.PassHostHeader {
+			setProxyUpstreamHostHeader(proxy, u)
+		} else {
+			setProxyDirector(proxy)
+		}
+		serveMux.Handle(path,
+			&UpstreamProxy{u, proxy, auth})
+	case "file":
+		if u.Fragment != "" {
+			path = u.Fragment
+		}
+		log.Printf("mapping path %q => file system %q", path, u.Path)
+		proxy := http.StripPrefix(path, http.FileServer(http.Dir(u.Path)))
+		serveMux.Handle(path, &UpstreamProxy{u, proxy, nil})
+	default:
+		panic(fmt.Sprintf("unknown upstream protocol %s", u.Scheme))
+	}
+}
+
+func setProxyUpstreamHostHeader(proxy *httputil.ReverseProxy, target *url.URL) {
+	director := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		director(req)
+		// use RequestURI so that we aren't unescaping encoded slashes in the request path
+		req.Host = target.Host
+		req.URL.Opaque = req.RequestURI
+		req.URL.RawQuery = ""
+	}
+}
+
+func setProxyDirector(proxy *httputil.ReverseProxy) {
+	director := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		director(req)
+		// use RequestURI so that we aren't unescaping encoded slashes in the request path
+		req.URL.Opaque = req.RequestURI
+		req.URL.RawQuery = ""
+	}
+}
+
+type UpstreamProxy struct {
+	upstream *url.URL
+	handler  http.Handler
+	auth     hmacauth.HmacAuth
+}
+
+func (u *UpstreamProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("GAP-Upstream-Address", u.upstream.Host)
+	if u.auth != nil {
+		r.Header.Set("GAP-Auth", w.Header().Get("GAP-Auth"))
+		u.auth.SignRequest(r)
+	}
+	u.handler.ServeHTTP(w, r)
+}

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -53,6 +53,8 @@ type GAPSignatureData struct {
 type Options struct {
 	SignatureData  *GAPSignatureData
 	PassHostHeader bool
+	ClientKey      string
+	ClientSecret   string
 }
 
 // this is what is used to handle urls in the "upstreams" option flag

--- a/backends/backends_test.go
+++ b/backends/backends_test.go
@@ -1,0 +1,62 @@
+package backends
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestNewReverseProxy(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		hostname, _, _ := net.SplitHostPort(r.Host)
+		w.Write([]byte(hostname))
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	backendHostname, backendPort, _ := net.SplitHostPort(backendURL.Host)
+	backendHost := net.JoinHostPort(backendHostname, backendPort)
+	proxyURL, _ := url.Parse(backendURL.Scheme + "://" + backendHost + "/")
+
+	proxyHandler := NewReverseProxy(proxyURL)
+	setProxyUpstreamHostHeader(proxyHandler, proxyURL)
+	frontend := httptest.NewServer(proxyHandler)
+	defer frontend.Close()
+
+	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
+	res, _ := http.DefaultClient.Do(getReq)
+	bodyBytes, _ := ioutil.ReadAll(res.Body)
+	if g, e := string(bodyBytes), backendHostname; g != e {
+		t.Errorf("got body %q; expected %q", g, e)
+	}
+}
+
+func TestEncodedSlashes(t *testing.T) {
+	var seen string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		seen = r.RequestURI
+	}))
+	defer backend.Close()
+
+	b, _ := url.Parse(backend.URL)
+	proxyHandler := NewReverseProxy(b)
+	setProxyDirector(proxyHandler)
+	frontend := httptest.NewServer(proxyHandler)
+	defer frontend.Close()
+
+	f, _ := url.Parse(frontend.URL)
+	encodedPath := "/a%2Fb/?c=1"
+	getReq := &http.Request{URL: &url.URL{Scheme: "http", Host: f.Host, Opaque: encodedPath}}
+	_, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("err %s", err)
+	}
+	if seen != encodedPath {
+		t.Errorf("got bad request %q expected %q", seen, encodedPath)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")
 	flagSet.String("resource", "", "The resource that is protected (Azure AD only)")
-	flagSet.String("validate-url", "", "Accessin token validation endpoint")
+	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 
 	emailDomains := StringArray{}
 	upstreams := StringArray{}
+	awsUpstreams := StringArray{}
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
 
@@ -69,11 +70,15 @@ func main() {
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")
 	flagSet.String("resource", "", "The resource that is protected (Azure AD only)")
-	flagSet.String("validate-url", "", "Access token validation endpoint")
+	flagSet.String("validate-url", "", "Accessin token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
+
+	flagSet.Var(&awsUpstreams, "aws-upstream", "the http url(s) of upstream servers that expect requests to be signed with AWS HMAC signatures.")
+	flagSet.String("aws-access-key-id", "", "the aws access key id to use when generating hmac signatures for aws-upstreams")
+	flagSet.String("aws-secret-access-key", "", "the aws secret access key to use when generating hmac signatures for aws-upstreams")
 
 	flagSet.Parse(os.Args[1:])
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -8,31 +8,15 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
-	"github.com/18F/hmacauth"
+	"github.com/bitly/oauth2_proxy/backends"
 	"github.com/bitly/oauth2_proxy/cookie"
 	"github.com/bitly/oauth2_proxy/providers"
 )
-
-const SignatureHeader = "GAP-Signature"
-
-var SignatureHeaders []string = []string{
-	"Content-Length",
-	"Content-Md5",
-	"Content-Type",
-	"Date",
-	"Authorization",
-	"X-Forwarded-User",
-	"X-Forwarded-Email",
-	"X-Forwarded-Access-Token",
-	"Cookie",
-	"Gap-Auth",
-}
 
 type OAuthProxy struct {
 	CookieSeed     string
@@ -69,79 +53,16 @@ type OAuthProxy struct {
 	Footer              string
 }
 
-type UpstreamProxy struct {
-	upstream string
-	handler  http.Handler
-	auth     hmacauth.HmacAuth
-}
-
-func (u *UpstreamProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("GAP-Upstream-Address", u.upstream)
-	if u.auth != nil {
-		r.Header.Set("GAP-Auth", w.Header().Get("GAP-Auth"))
-		u.auth.SignRequest(r)
-	}
-	u.handler.ServeHTTP(w, r)
-}
-
-func NewReverseProxy(target *url.URL) (proxy *httputil.ReverseProxy) {
-	return httputil.NewSingleHostReverseProxy(target)
-}
-func setProxyUpstreamHostHeader(proxy *httputil.ReverseProxy, target *url.URL) {
-	director := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		director(req)
-		// use RequestURI so that we aren't unescaping encoded slashes in the request path
-		req.Host = target.Host
-		req.URL.Opaque = req.RequestURI
-		req.URL.RawQuery = ""
-	}
-}
-func setProxyDirector(proxy *httputil.ReverseProxy) {
-	director := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		director(req)
-		// use RequestURI so that we aren't unescaping encoded slashes in the request path
-		req.URL.Opaque = req.RequestURI
-		req.URL.RawQuery = ""
-	}
-}
-func NewFileServer(path string, filesystemPath string) (proxy http.Handler) {
-	return http.StripPrefix(path, http.FileServer(http.Dir(filesystemPath)))
-}
-
 func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	serveMux := http.NewServeMux()
-	var auth hmacauth.HmacAuth
-	if sigData := opts.signatureData; sigData != nil {
-		auth = hmacauth.NewHmacAuth(sigData.hash, []byte(sigData.key),
-			SignatureHeader, SignatureHeaders)
+
+	for _, b := range opts.proxyURLs {
+		backends.Register(b.BackendType, b.Url, &backends.Options{
+			SignatureData:  opts.signatureData,
+			PassHostHeader: opts.PassHostHeader,
+		}, serveMux)
 	}
-	for _, u := range opts.proxyURLs {
-		path := u.Path
-		switch u.Scheme {
-		case "http", "https":
-			u.Path = ""
-			log.Printf("mapping path %q => upstream %q", path, u)
-			proxy := NewReverseProxy(u)
-			if !opts.PassHostHeader {
-				setProxyUpstreamHostHeader(proxy, u)
-			} else {
-				setProxyDirector(proxy)
-			}
-			serveMux.Handle(path,
-				&UpstreamProxy{u.Host, proxy, auth})
-		case "file":
-			if u.Fragment != "" {
-				path = u.Fragment
-			}
-			log.Printf("mapping path %q => file system %q", path, u.Path)
-			proxy := NewFileServer(path, u.Path)
-			serveMux.Handle(path, &UpstreamProxy{path, proxy, nil})
-		default:
-			panic(fmt.Sprintf("unknown upstream protocol %s", u.Scheme))
-		}
-	}
+
 	for _, u := range opts.CompiledRegex {
 		log.Printf("compiled skip-auth-regex => %q", u)
 	}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -57,7 +57,6 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	serveMux := http.NewServeMux()
 
 	for _, p := range opts.proxyURLs {
-		log.Printf("about to register: %+v, %+v \n", p, *p.Options)
 		backends.Register(p.BackendType, p.Url, p.Options, serveMux)
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -56,11 +56,9 @@ type OAuthProxy struct {
 func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	serveMux := http.NewServeMux()
 
-	for _, b := range opts.proxyURLs {
-		backends.Register(b.BackendType, b.Url, &backends.Options{
-			SignatureData:  opts.signatureData,
-			PassHostHeader: opts.PassHostHeader,
-		}, serveMux)
+	for _, p := range opts.proxyURLs {
+		log.Printf("about to register: %+v, %+v \n", p, *p.Options)
+		backends.Register(p.BackendType, p.Url, p.Options, serveMux)
 	}
 
 	for _, u := range opts.CompiledRegex {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -4,12 +4,12 @@ import (
 	"crypto"
 	"encoding/base64"
 	"github.com/18F/hmacauth"
+	"github.com/bitly/oauth2_proxy/backends"
 	"github.com/bitly/oauth2_proxy/providers"
 	"github.com/bmizerany/assert"
 	"io"
 	"io/ioutil"
 	"log"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -22,58 +22,6 @@ import (
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 
-}
-
-func TestNewReverseProxy(t *testing.T) {
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		hostname, _, _ := net.SplitHostPort(r.Host)
-		w.Write([]byte(hostname))
-	}))
-	defer backend.Close()
-
-	backendURL, _ := url.Parse(backend.URL)
-	backendHostname, backendPort, _ := net.SplitHostPort(backendURL.Host)
-	backendHost := net.JoinHostPort(backendHostname, backendPort)
-	proxyURL, _ := url.Parse(backendURL.Scheme + "://" + backendHost + "/")
-
-	proxyHandler := NewReverseProxy(proxyURL)
-	setProxyUpstreamHostHeader(proxyHandler, proxyURL)
-	frontend := httptest.NewServer(proxyHandler)
-	defer frontend.Close()
-
-	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
-	res, _ := http.DefaultClient.Do(getReq)
-	bodyBytes, _ := ioutil.ReadAll(res.Body)
-	if g, e := string(bodyBytes), backendHostname; g != e {
-		t.Errorf("got body %q; expected %q", g, e)
-	}
-}
-
-func TestEncodedSlashes(t *testing.T) {
-	var seen string
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		seen = r.RequestURI
-	}))
-	defer backend.Close()
-
-	b, _ := url.Parse(backend.URL)
-	proxyHandler := NewReverseProxy(b)
-	setProxyDirector(proxyHandler)
-	frontend := httptest.NewServer(proxyHandler)
-	defer frontend.Close()
-
-	f, _ := url.Parse(frontend.URL)
-	encodedPath := "/a%2Fb/?c=1"
-	getReq := &http.Request{URL: &url.URL{Scheme: "http", Host: f.Host, Opaque: encodedPath}}
-	_, err := http.DefaultClient.Do(getReq)
-	if err != nil {
-		t.Fatalf("err %s", err)
-	}
-	if seen != encodedPath {
-		t.Errorf("got bad request %q expected %q", seen, encodedPath)
-	}
 }
 
 func TestRobotsTxt(t *testing.T) {
@@ -704,7 +652,7 @@ func (st *SignatureTest) MakeRequestWithExpectedKey(method, body, key string) {
 	req.AddCookie(cookie)
 	// This is used by the upstream to validate the signature.
 	st.authenticator.auth = hmacauth.NewHmacAuth(
-		crypto.SHA1, []byte(key), SignatureHeader, SignatureHeaders)
+		crypto.SHA1, []byte(key), backends.GAPSignatureHeader, backends.GAPSignatureHeaders)
 	proxy.ServeHTTP(st.rw, req)
 }
 

--- a/options.go
+++ b/options.go
@@ -130,7 +130,7 @@ func parseUpstreamUrl(u string, msgs []string) (*url.URL, []string) {
 func (o *Options) Validate() error {
 	msgs := make([]string, 0)
 	if len(o.Upstreams) < 1 && len(o.AwsUpstreams) < 1 {
-		msgs = append(msgs, "missing setting: at least one set of upstreams is required, either upstreams or aws-upstreams requires")
+		msgs = append(msgs, "missing setting,at least one set of upstreams is required: upstreams or aws-upstreams required")
 	}
 	if o.CookieSecret == "" {
 		msgs = append(msgs, "missing setting: cookie-secret")

--- a/options.go
+++ b/options.go
@@ -73,8 +73,8 @@ type Options struct {
 	// These options allow for defining a list of aws upstream servers. Requests to these upstreams will be signed with
 	// the provided key/secret provided as well. Env vars are read from the standard aws env var names.
 	AwsUpstreams       []string `flag:"aws-upstream" cfg:"aws_upstreams"`
-	AwsAccessKeyId     string   `flag:"aws-access-key-id" cfg"aws_access_key_id" env:"AWS_ACCESS_KEY"`
-	AwsSecretAccessKey string   `flag:"aws-secret-access-key" cfg"aws_secret_access_key" env:"AWS_SECRET_KEY"`
+	AwsAccessKeyId     string   `flag:"aws-access-key-id" cfg:"aws_access_key_id" env:"AWS_ACCESS_KEY"`
+	AwsSecretAccessKey string   `flag:"aws-secret-access-key" cfg:"aws_secret_access_key" env:"AWS_SECRET_KEY"`
 
 	// internal values that are set after config validation
 	redirectURL   *url.URL
@@ -169,8 +169,8 @@ func (o *Options) Validate() error {
 			Url:         upstreamURL,
 			BackendType: backends.BackendTypeAws,
 			Options: &backends.Options{
-				ClientKey:    o.AwsAccessKeyId,
-				ClientSecret: o.AwsSecretAccessKey,
+				AwsAccessKeyId:     o.AwsAccessKeyId,
+				AwsSecretAccessKey: o.AwsSecretAccessKey,
 			},
 		})
 	}

--- a/options.go
+++ b/options.go
@@ -130,7 +130,7 @@ func parseUpstreamUrl(u string, msgs []string) (*url.URL, []string) {
 func (o *Options) Validate() error {
 	msgs := make([]string, 0)
 	if len(o.Upstreams) < 1 && len(o.AwsUpstreams) < 1 {
-		msgs = append(msgs, "missing setting,at least one set of upstreams is required: upstreams or aws-upstreams required")
+		msgs = append(msgs, "missing setting: upstreams or aws-upstreams required")
 	}
 	if o.CookieSecret == "" {
 		msgs = append(msgs, "missing setting: cookie-secret")

--- a/options.go
+++ b/options.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/18F/hmacauth"
+	"github.com/bitly/oauth2_proxy/backends"
 	"github.com/bitly/oauth2_proxy/providers"
 )
 
@@ -70,17 +70,23 @@ type Options struct {
 
 	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
+	// These options allow for defining a list of aws upstream servers. Requests to these upstreams will be signed with
+	// the provided key/secret provided as well. Env vars are read from the standard aws env var names.
+	AwsUpstreams       []string `flag:"aws-upstream" cfg:"aws_upstreams"`
+	AwsAccessKeyId     string   `flag:"aws-access-key-id" cfg"aws_access_key_id" env:"AWS_ACCESS_KEY_ID"`
+	AwsSecretAccessKey string   `flag:"aws-secret-access-key" cfg"aws_secret_access_key" env:"AWS_SECRET_ACCESS_KEY"`
+
 	// internal values that are set after config validation
 	redirectURL   *url.URL
-	proxyURLs     []*url.URL
+	proxyURLs     []*proxyURL
 	CompiledRegex []*regexp.Regexp
 	provider      providers.Provider
-	signatureData *SignatureData
+	signatureData *backends.GAPSignatureData
 }
 
-type SignatureData struct {
-	hash crypto.Hash
-	key  string
+type proxyURL struct {
+	Url         *url.URL
+	BackendType string
 }
 
 func NewOptions() *Options {
@@ -112,10 +118,18 @@ func parseURL(to_parse string, urltype string, msgs []string) (*url.URL, []strin
 	return parsed, msgs
 }
 
+func parseUpstreamUrl(u string, msgs []string) (*url.URL, []string) {
+	upstreamURL, msgs := parseURL(u, "upstream", msgs)
+	if upstreamURL.Path == "" {
+		upstreamURL.Path = "/"
+	}
+	return upstreamURL, msgs
+}
+
 func (o *Options) Validate() error {
 	msgs := make([]string, 0)
-	if len(o.Upstreams) < 1 {
-		msgs = append(msgs, "missing setting: upstream")
+	if len(o.Upstreams) < 1 && len(o.AwsUpstreams) < 1 {
+		msgs = append(msgs, "missing setting: at least one set of upstreams is required, either upstreams or aws-upstreams requires")
 	}
 	if o.CookieSecret == "" {
 		msgs = append(msgs, "missing setting: cookie-secret")
@@ -133,16 +147,21 @@ func (o *Options) Validate() error {
 	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)
 
 	for _, u := range o.Upstreams {
-		upstreamURL, err := url.Parse(u)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf(
-				"error parsing upstream=%q %s",
-				upstreamURL, err))
-		}
-		if upstreamURL.Path == "" {
-			upstreamURL.Path = "/"
-		}
-		o.proxyURLs = append(o.proxyURLs, upstreamURL)
+		var upstreamURL *url.URL
+		upstreamURL, msgs = parseUpstreamUrl(u, msgs)
+		o.proxyURLs = append(o.proxyURLs, &proxyURL{
+			Url:         upstreamURL,
+			BackendType: backends.BackendTypeDefault,
+		})
+	}
+
+	for _, u := range o.AwsUpstreams {
+		var upstreamURL *url.URL
+		upstreamURL, msgs = parseUpstreamUrl(u, msgs)
+		o.proxyURLs = append(o.proxyURLs, &proxyURL{
+			Url:         upstreamURL,
+			BackendType: backends.BackendTypeAws,
+		})
 	}
 
 	for _, u := range o.SkipAuthRegex {
@@ -258,7 +277,7 @@ func parseSignatureKey(o *Options, msgs []string) []string {
 		return append(msgs, "unsupported signature hash algorithm: "+
 			o.SignatureKey)
 	} else {
-		o.signatureData = &SignatureData{hash, secretKey}
+		o.signatureData = &backends.GAPSignatureData{hash, secretKey}
 	}
 	return msgs
 }


### PR DESCRIPTION
## Proposal to add support for more granular backends

### Why?
- Currently all upstream servers are specified in the "--upstreams" flag.
- There is also a specific implementation of "GAP-Auth" signatures specified using the "--signature-data" flag. This signature is applied to all upstreams when specified. While it's unlikely that an upstream server will be outside your control, it seems odd to leak this data to upstreams that do not need the signature.
- The "GAP-Auth" header doesn't help if you want to sign requests for AWS services. The specific use case for me is AWS's managed ElasticSearch, which can only be protected using AWS HMAC signatures.

### How?
- Use the same pattern as "providers" to create a set of "backends".
- Currently split in to two sets:
    - "Default" uses the existing logic to handle all the servers passed in as --upstreams, and maintain retro-compatibility.
    - "Aws" uses a new "--aws-upstreams" flag to specify a list of upstreams that need AWS style hmac signatures.

### Future?
- Things like "GAP-Auth" could be moved in to a "--gap-auth-upstreams" and handled with a specific backend.
- If breaking retro-compatibility is OK, then creating a "backend" interface might make sense, but currently it's using a catch all "options" struct. Each backend uses the "options" that it knows/cares about.

